### PR TITLE
[feat] 네이버 / 카카오톡 소셜 로그인 로직 구현 완료 + 추후 백엔드 부분 추가 필요

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-VITE_NAVER_CLIENT_ID=B5PSQXhPBRXsmRT3M8ul
-VITE_NAVER_REDIRECT_URI=http://localhost:5173/auth/naver/callback
-
-VITE_KAKAO_CLIENT_ID=c54b67c70db9d7766009efd1e76f48c8
-VITE_KAKAO_REDIRECT_URI=http://localhost:5173/auth/kakao/callback

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+.env
 node_modules
 dist
 dist-ssr

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,0 +1,7 @@
+VITE_KAKAO_CLIENT_ID=your-kakao-client-id
+VITE_KAKAO_REDIRECT_URI=http://localhost:5173/auth/kakao/callback
+VITE_KAKAO_CLIENT_SECRET=your-kakao-secret
+
+VITE_NAVER_CLIENT_ID=your-naver-client-id
+VITE_NAVER_REDIRECT_URI=http://localhost:5173/auth/naver/callback
+VITE_NAVER_CLIENT_SECRET=your-naver-secret

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import PrivacyPolicy from './components/PrivacyPolicy/index.tsx';
 
 import GroupAddpage from './pages/GroupAddpage/Admin.tsx';
 import Mypage from './pages/Mypage/index.tsx';
+import KakaoCallBack from './components/KakaoCallback/index.tsx';
 
 function App() {
   return (
@@ -21,6 +22,7 @@ function App() {
       </Route>
 
       <Route path="/loginpage" element={<Loginpage />} />
+      <Route path="/auth/kakao/callback" element={<KakaoCallBack />} />
     </Routes>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import PrivacyPolicy from './components/PrivacyPolicy/index.tsx';
 import GroupAddpage from './pages/GroupAddpage/Admin.tsx';
 import Mypage from './pages/Mypage/index.tsx';
 import KakaoCallBack from './components/KakaoCallback/index.tsx';
+import NaverCallback from './components/NaverCallback/index.tsx';
 
 function App() {
   return (
@@ -23,6 +24,7 @@ function App() {
 
       <Route path="/loginpage" element={<Loginpage />} />
       <Route path="/auth/kakao/callback" element={<KakaoCallBack />} />
+      <Route path="/auth/naver/callback" element={<NaverCallback />} />
     </Routes>
   );
 }

--- a/src/components/KakaoCallback/index.tsx
+++ b/src/components/KakaoCallback/index.tsx
@@ -39,8 +39,7 @@ function KakaoCallBack() {
         },
       );
 
-
-            /** 백엔드에서 토큰을 어떤 이름으로 주는지 확인이 필요
+      /** 백엔드에서 토큰을 어떤 이름으로 주는지 확인이 필요
        *  아래 처럼 줄 수 있기 때문에...
        * {
           "access": "eyJ0eXAiOiJKV1QiLCJhbGci...",
@@ -49,7 +48,7 @@ function KakaoCallBack() {
           
        */
       // 백엔드가 어떻게 데이터를 주는지 확인 필수!!!!!!!
-      console.log(response.data)
+      console.log(response.data);
       const kakaoAccessToken = response.data.access_token;
 
       sendTokenToBackend(kakaoAccessToken);

--- a/src/components/KakaoCallback/index.tsx
+++ b/src/components/KakaoCallback/index.tsx
@@ -22,25 +22,14 @@ function KakaoCallBack() {
 
   const getKakaoToken = async (code: string) => {
     try {
-      console.log('🚀 전송하는 파라미터:');
-      console.log(
-        new URLSearchParams({
-          grant_type: 'authorization_code',
-          client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
-          redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URI,
-          code: code,
-        }).toString(),
-      );
-      console.log('client_id:', import.meta.env.VITE_KAKAO_CLIENT_ID);
-      console.log('redirect_uri:', import.meta.env.VITE_KAKAO_REDIRECT_URI);
-      console.log('code:', code);
-
       const response = await axios.post(
         'https://kauth.kakao.com/oauth/token',
         new URLSearchParams({
           grant_type: 'authorization_code',
           client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
           redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URI,
+          client_secret: import.meta.env.VITE_KAKAO_CLIENT_SECRET,
+
           code: code,
         }),
         {
@@ -50,15 +39,35 @@ function KakaoCallBack() {
         },
       );
 
-      const accessToken = response.data.access_token;
+      const kakaoAccessToken = response.data.access_token;
 
-      localStorage.setItem('token', accessToken);
+      sendTokenToBackend(kakaoAccessToken);
+
+      localStorage.setItem('token', kakaoAccessToken);
 
       navigate('/');
     } catch (error) {
       console.log('토큰 요청 실패 ❌', error);
     }
     return <div> 로그인 처리 중입니다...</div>;
+  };
+
+  const sendTokenToBackend = async (accessToken: string) => {
+    try {
+      const response = await axios.post(
+        'http://localhost:8000/auth/social/kakao',
+        {},
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        },
+      );
+      const myJwtToken = response.data.token;
+      localStorage.setItem('token', myJwtToken);
+    } catch (error) {
+      console.log('백엔드 로그인 실패!');
+    }
   };
 
   return <></>;

--- a/src/components/KakaoCallback/index.tsx
+++ b/src/components/KakaoCallback/index.tsx
@@ -1,0 +1,67 @@
+import axios from 'axios';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function KakaoCallBack() {
+  const navigate = useNavigate();
+
+  /**
+   * const url = new URL(window.location.href);
+    url.searchParams.get("code"); // 👉 "abc123"
+    url.pathname; // 👉 "/oauth/kakao"
+    url.origin; // 👉 "https://myapp.com"
+   * 
+   */
+  useEffect(() => {
+    const code = new URL(window.location.href).searchParams.get('code');
+
+    if (code) {
+      getKakaoToken(code);
+    }
+  }, []);
+
+  const getKakaoToken = async (code: string) => {
+    try {
+      console.log('🚀 전송하는 파라미터:');
+      console.log(
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
+          redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URI,
+          code: code,
+        }).toString(),
+      );
+      console.log('client_id:', import.meta.env.VITE_KAKAO_CLIENT_ID);
+      console.log('redirect_uri:', import.meta.env.VITE_KAKAO_REDIRECT_URI);
+      console.log('code:', code);
+
+      const response = await axios.post(
+        'https://kauth.kakao.com/oauth/token',
+        new URLSearchParams({
+          grant_type: 'authorization_code',
+          client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
+          redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URI,
+          code: code,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+          },
+        },
+      );
+
+      const accessToken = response.data.access_token;
+
+      localStorage.setItem('token', accessToken);
+
+      navigate('/');
+    } catch (error) {
+      console.log('토큰 요청 실패 ❌', error);
+    }
+    return <div> 로그인 처리 중입니다...</div>;
+  };
+
+  return <></>;
+}
+
+export default KakaoCallBack;

--- a/src/components/KakaoCallback/index.tsx
+++ b/src/components/KakaoCallback/index.tsx
@@ -39,6 +39,17 @@ function KakaoCallBack() {
         },
       );
 
+
+            /** 백엔드에서 토큰을 어떤 이름으로 주는지 확인이 필요
+       *  아래 처럼 줄 수 있기 때문에...
+       * {
+          "access": "eyJ0eXAiOiJKV1QiLCJhbGci...",
+          "refresh": "eyJ0eXAiOiJKV1QiLCJhbGci..."
+        }
+          
+       */
+      // 백엔드가 어떻게 데이터를 주는지 확인 필수!!!!!!!
+      console.log(response.data)
       const kakaoAccessToken = response.data.access_token;
 
       sendTokenToBackend(kakaoAccessToken);
@@ -55,7 +66,8 @@ function KakaoCallBack() {
   const sendTokenToBackend = async (accessToken: string) => {
     try {
       const response = await axios.post(
-        'http://localhost:8000/auth/social/kakao',
+        // 백엔드 서버 주소 필요
+        'http://100.26.111.172/ilog/account/social-login/',
         {},
         {
           headers: {

--- a/src/components/KakaoLogin/index.tsx
+++ b/src/components/KakaoLogin/index.tsx
@@ -7,6 +7,7 @@ const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 const handleKakaoLogin = () => {
   const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}`;
 
+  //이 방식 자체가 브라우저에서 자동으로 GET 요청을 보내는 거야! ✅
   window.location.href = KAKAO_AUTH_URL; // ✅ 카카오 로그인 페이지로 이동
 };
 

--- a/src/components/NaverCallback/index.tsx
+++ b/src/components/NaverCallback/index.tsx
@@ -1,0 +1,65 @@
+import axios from 'axios';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+function NaverCallback() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    const stateToken = new URL(window.location.href).searchParams.get('state');
+    const code = new URL(window.location.href).searchParams.get('code');
+
+    if (code && stateToken) {
+      getNaverToken(code, stateToken);
+    }
+  }, []);
+
+  const getNaverToken = async (code: string, stateToken: string) => {
+    try {
+      const response = await axios.post(
+        'http://100.26.111.172/ilog/account/social-login/',
+        {
+          code: code,
+          state: stateToken,
+        },
+      );
+      /** CORS 정책으로 인해 프론트에서 네이버 서버에 직접 코드 발급은 불가능 함 
+       // const response = await axios.post(
+       //   'https://nid.naver.com/oauth2.0/token',
+       //   new URLSearchParams({
+       //     grant_type: 'authorization_code',
+       //     client_id: import.meta.env.VITE_NAVER_CLIENT_ID,
+       //     client_secret: import.meta.env.VITE_NAVER_CLIENT_SECRET,
+       //     redirect_uri: import.meta.env.VITE_NAVER_REDIRECT_URI,
+       //     state: stateToken,
+       //     code: code,
+       //   }),
+       // );
+       * 
+       */
+
+      /** 백엔드에서 토큰을 어떤 이름으로 주는지 확인이 필요
+       *  아래 처럼 줄 수 있기 때문에...
+       * {
+          "access": "eyJ0eXAiOiJKV1QiLCJhbGci...",
+          "refresh": "eyJ0eXAiOiJKV1QiLCJhbGci..."
+        }
+          
+       */
+      // 백엔드가 어떻게 데이터를 주는지 확인 필수!!!!!!!
+      console.log(response.data);
+
+      const myJwtToken = response.data.token;
+
+      localStorage.setItem('token', myJwtToken);
+
+      navigate('/');
+    } catch (error) {
+      console.log('토큰 요청 실패 ❌', error);
+    }
+    return <div> 로그인 처리 중입니다...</div>;
+  };
+
+  return <></>;
+}
+
+export default NaverCallback;

--- a/src/components/NaverLogin/index.tsx
+++ b/src/components/NaverLogin/index.tsx
@@ -2,10 +2,14 @@ import './Naverlogin.scss';
 import naver_logo from '../../assets/naver-logo.png';
 const NAVER_CLIENT_ID = import.meta.env.VITE_NAVER_CLIENT_ID;
 const NAVER_REDIRECT_URI = import.meta.env.VITE_NAVER_REDIRECT_URI;
+const STATE = ((length = 8) => {
+  const randomstring = Math.random().toString(16).substring(2, length);
+  return randomstring;
+})();
 
 const NaverLogin = () => {
   const handleLogin = () => {
-    const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${NAVER_REDIRECT_URI}&state=RANDOM_STRING`;
+    const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${NAVER_REDIRECT_URI}&state=RANDOM_STRING&state=${STATE}`;
 
     window.location.href = NAVER_AUTH_URL; // ✅ 네이버 로그인 페이지로 이동
   };


### PR DESCRIPTION

callback 페이지 추가하여 네이버와 카카오톡 로직 구현

네이버는 CORS 정책 이슈로 인해 백엔드로 코드 요청 
env 파일을 ginigonre 에 올려놓지 않아서 
네이버 / 카카오 클라이언트 ID와 REDIRECT URI 가 노출됨
다행히 네이버 / 카카오 CLIENT_SECRET는 적혀져 있지 않았음

일단 카카오의 클라이언트 ID 재발급 후 교체 완료 했음
그리고 네이버는 클라이언트 시크릿키를 재발급 받음
모든 파일 env 파일에 재작성 후 gitignore 에 올려놓음 